### PR TITLE
speed up ci

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -32,6 +32,8 @@ jobs:
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
           tool-cache: false
+          large-packages: false
+          docker-images: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,6 +35,8 @@ jobs:
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
           tool-cache: false
+          large-packages: false
+          docker-images: false
 
       - name: Set up Python ${{ matrix.pyv }}
         uses: actions/setup-python@v5


### PR DESCRIPTION
Disabling  `large-packages` and `docker-images` makes the free disk space action a bit faster