### PR TITLE
add HealthCheck endpoint, enable reflection

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,21 @@ pip install vllm-tgis-adapter
 python -m vllm_tgis_adapter
 ```
 
+### HealthCheck CLI
+
+Installing the adapter also install a grpc healthcheck cli that can be used to monitor the status of the grpc server:
+
+```console
+$ grpc_healtheck
+health check...status: SERVING
+```
+
+See usage with
+
+```bash
+grpc_healthcheck --help
+```
+
 ## Build
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ dependencies = [
   "vllm>=0.4.3",
   "prometheus_client==0.20.0",
   "grpcio==1.62.1",
+  "grpcio-health-checking==1.62.1",
+  "grpcio-reflection==1.62.1",
   "transformers",
   "accelerate==0.28.0",
   "hf-transfer==0.1.6"
@@ -41,7 +43,8 @@ Source = "https://github.com/dtrifiro/vllm_tgis_adapter"
 [project.optional-dependencies]
 tests = [
   "pytest==8.2.0",
-  "pytest-cov==5.0.0"
+  "pytest-cov==5.0.0",
+  "pytest-mock==3.14.0"
 ]
 dev = [
   "vllm_tgis_adapter[tests]",
@@ -144,7 +147,8 @@ ignore = [
   "FIX",  # todo messages
   "ERA001",  # commented out code
   # formatting
-  "COM812"
+  "COM812",
+  "RET504"  # Unnecessary assignment to `args` before `return` statement
 ]
 select = ["ALL"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ dependencies = [
 Issues = "https://github.com/dtrifiro/vllm_tgis_adapter/issues"
 Source = "https://github.com/dtrifiro/vllm_tgis_adapter"
 
+[project.scripts]
+grpc_healthcheck = "vllm_tgis_adapter.healthcheck:cli"
+
 [project.optional-dependencies]
 tests = [
   "pytest==8.2.0",
@@ -73,7 +76,7 @@ vllm_tgis_adapter = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "-ra"
+addopts = "-ra -W error::grpc.experimental.ExperimentalApiWarning"
 
 [tool.coverage.run]
 branch = true
@@ -158,6 +161,7 @@ select = ["ALL"]
   "N802",  # name should be lowercase
   "ERA001"  # Found commented-out code
 ]
+"src/vllm_tgis_adapter/healthcheck.py" = ["T201"]
 "src/vllm_tgis_adapter/_version.py" = ["ALL"]
 "tests/**" = ["S", "ARG001", "ARG002", "ANN"]
 "setup.py" = [

--- a/src/vllm_tgis_adapter/healthcheck.py
+++ b/src/vllm_tgis_adapter/healthcheck.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import argparse
+import sys
+import warnings
+
+import grpc
+import grpc.experimental  # this is required for grpc_health
+from grpc_health.v1.health_pb2 import HealthCheckRequest
+from grpc_health.v1.health_pb2_grpc import Health
+
+from vllm_tgis_adapter.grpc.grpc_server import TextGenerationService
+
+warnings.simplefilter(
+    action="ignore", category=grpc.experimental.ExperimentalApiWarning
+)
+
+
+def health_check(
+    *,
+    server_url: str = "localhost:8033",
+    service: str | None = None,
+    insecure: bool = True,
+    timeout: float = 1,
+) -> bool:
+    print("health check...", end="")
+    request = HealthCheckRequest(service=service)
+    try:
+        response = Health.Check(
+            request=request,
+            target=server_url,
+            timeout=timeout,
+            insecure=insecure,
+        )
+    except grpc.RpcError as e:
+        print(f"Health.Check failed: code={e.code()}, details={e.details()}")
+        return False
+
+    print(str(response).strip())
+    return response.status == response.SERVING
+
+
+def cli() -> None:
+    args = parse_args()
+    if not health_check(
+        server_url=args.server_url,
+        service=args.service_name,
+        insecure=args.insecure,
+        timeout=args.timeout,
+    ):
+        sys.exit(1)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.formatter_class = argparse.ArgumentDefaultsHelpFormatter
+    group = parser.add_mutually_exclusive_group(required=False)
+    group.add_argument(
+        "--insecure",
+        dest="insecure",
+        action="store_true",
+        help="Use an insecure connection",
+    )
+    group.add_argument(
+        "--secure",
+        dest="secure",
+        action="store_true",
+        help="Use a secure connection",
+    )
+    group.set_defaults(insecure=True, secure=False)
+    parser.add_argument(
+        "--server-url",
+        type=str,
+        help="grpc server url (`host:port`)",
+        default="localhost:8033",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        help="Timeout for healthcheck request",
+        default=1,
+    )
+    parser.add_argument(
+        "--service-name",
+        type=str,
+        help="Name of the service to check",
+        required=False,
+        default=TextGenerationService.SERVICE_NAME,
+    )
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    cli()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,112 @@
+import asyncio
+import sys
+import threading
+
+import pytest
+from grpc_health.v1.health_pb2 import HealthCheckRequest
+from grpc_health.v1.health_pb2_grpc import Health
+from vllm import AsyncLLMEngine
+from vllm.config import DeviceConfig
+from vllm.engine.async_llm_engine import _AsyncLLMEngine
+from vllm.entrypoints.openai.cli_args import make_arg_parser
+
+from vllm_tgis_adapter.grpc.grpc_server import TextGenerationService, start_grpc_server
+from vllm_tgis_adapter.tgis_utils.args import (
+    EnvVarArgumentParser,
+    add_tgis_args,
+    postprocess_tgis_args,
+)
+
+from .utils import get_random_port, wait_until
+
+
+@pytest.fixture()
+def engine(mocker, monkeypatch):
+    """Return a mocked vLLM engine."""
+    engine = mocker.Mock(spec=AsyncLLMEngine)
+    engine.engine = mocker.Mock(spec=_AsyncLLMEngine)
+    mocker.patch("torch.cuda.memory_summary", return_value="mocked")
+    engine.engine.device_config = mocker.Mock(spec=DeviceConfig)
+    engine.engine.device_config.device = "cuda"
+
+    engine.engine.stat_logger = "mocked"
+
+    return engine
+
+
+@pytest.fixture()
+def args(monkeypatch, grpc_server_thread_port):
+    # avoid parsing pytest arguments as vllm/vllm_tgis_adapter arguments
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "__main__.py",
+            f"--grpc-port={grpc_server_thread_port}",
+        ],
+    )
+
+    parser = EnvVarArgumentParser(parser=make_arg_parser())
+    parser = add_tgis_args(parser)
+    args = postprocess_tgis_args(parser.parse_args())
+
+    return args
+
+
+@pytest.fixture()
+def grpc_server_thread_port():
+    """Port for grpc server."""
+    return get_random_port()
+
+
+@pytest.fixture()
+def grpc_server_url(grpc_server_thread_port):
+    """Port for grpc server."""
+    return f"localhost:{grpc_server_thread_port}"
+
+
+@pytest.fixture()
+def grpc_server(engine, args, grpc_server_url):
+    """Spins up grpc server in a background thread."""
+
+    def health_check():
+        print("Waiting for server to be up...")  # noqa: T201
+        request = HealthCheckRequest(service=TextGenerationService.SERVICE_NAME)
+        resp = Health.Check(
+            request=request,
+            target=grpc_server_url,
+            timeout=1,
+            insecure=True,
+        )
+        assert resp.status == resp.SERVING
+        print("Server is up")  # noqa: T201
+
+    global server  # noqa: PLW0602
+
+    loop = asyncio.new_event_loop()
+
+    async def run_server():
+        global server  # noqa: PLW0603
+
+        server = await start_grpc_server(engine, args)
+        while server._server.is_running():  # noqa: SLF001
+            await asyncio.sleep(1)
+
+    def target():
+        loop.run_until_complete(run_server())
+
+    t = threading.Thread(target=target)
+    t.start()
+
+    async def stop():
+        global server  # noqa: PLW0602
+
+        await server.stop(grace=None)
+        await server.wait_for_termination()
+
+    try:
+        wait_until(_health_check)
+        yield server
+    finally:
+        loop.create_task(stop())  # noqa: RUF006
+        t.join()

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -1,0 +1,3 @@
+def test_startup(grpc_server):
+    """Test that the grpc_server fixture starts up properly."""
+    assert grpc_server._server.is_running()  # noqa: SLF001

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,34 @@
+import socket
+import time
+from contextlib import closing
+from typing import Callable, TypeVar
+
+_T = TypeVar("_T")
+
+
+def get_random_port():
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("", 0))
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        port = s.getsockname()[1]
+        return port
+
+
+def wait_until(
+    pred: Callable[..., _T],
+    timeout: float = 30,
+    pause: float = 0.5,
+) -> _T:
+    start = time.perf_counter()
+    exc = None
+
+    while (time.perf_counter() - start) < timeout:
+        try:
+            value = pred()
+        except Exception as e:  # noqa: BLE001
+            exc = e
+        else:
+            return value
+        time.sleep(pause)
+
+    raise TimeoutError("timed out waiting") from exc


### PR DESCRIPTION
This PR adds a grpc healthchecking mechanism using `grpcio-health-checking` (https://pypi.org/project/grpcio-health-checking/) and enables reflection aswell using `grpcio-reflection` (https://pypi.org/project/grpcio-reflection/)

The healthcheck endpoint is tested by spinning up a grpc server with a mock engine.